### PR TITLE
update lib/pq to support SCRAM-SHA-256 authentication

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -34,8 +34,8 @@
   version = "3.3.0"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/lib/pq"
+  version = "1.1.0"
 
 [[constraint]]
   name = "github.com/go-redis/redis"


### PR DESCRIPTION
update `lib/pq` to support SCRAM-SHA-256 authentication introduced in Postgres 10